### PR TITLE
Specified scope of CallbackWomen criteria

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -4,7 +4,7 @@ A crowdsourced list of resources for women who want to get into public speaking.
 
 ###For Speakers:###
 
-+ [@callbackwomen](https://twitter.com/CallbackWomen) — Follow Call Back Women to find new speaking opportunities in the tech community.
++ [@callbackwomen](https://twitter.com/CallbackWomen) — follow CallbackWomen to find opportunities for professional programmers to speak at professional programming conferences. Website: [CallbackwWmen.com](http://callbackwomen.com)
 + [9 Things Great Speakers Always Do](http://www.inc.com/jeff-haden/9-simple-things-great-speakers-always-do-mon.html) — An Inc. article by Jeff Hayden on the things great speakers do to make a real impact on their audiences.
 + [Ladies In Tech](http://ladiesintech.com/) — Articles and podcasts from women in public speaking.
 + [Speaking.io](http://speaking.io/) — Thoughts on public speaking by Zach Holman.


### PR DESCRIPTION
CallbackWomen is pretty narrowly scoped. Strictly for professional programming conferences seeking programmers to speak via open CFP process.
